### PR TITLE
フレームワーク総合課題1 課題の詳細を追加

### DIFF
--- a/html/laravel/app/Http/Controllers/TaskController.php
+++ b/html/laravel/app/Http/Controllers/TaskController.php
@@ -102,6 +102,7 @@ class TaskController extends Controller
         $request->validate([
             'task_kind_id' => 'required|integer',
             'name' => 'required|string|max:255',
+            'detail' => 'nullable|string|max:1000',
             'task_status_id' => 'required|integer',
             'assigner_id' => 'nullable|integer',
             'task_category_id' => 'nullable|integer',
@@ -113,6 +114,7 @@ class TaskController extends Controller
             'project_id' => $project->id,
             'task_kind_id' => $request->task_kind_id,
             'name' => $request->name,
+            'detail' => $request->detail,
             'task_status_id' => $request->task_status_id,
             'assigner_id' => $request->assigner_id,
             'task_category_id' => $request->task_category_id,
@@ -174,6 +176,7 @@ class TaskController extends Controller
         $request->validate([
             'task_kind_id' => 'required|integer',
             'name' => 'required|string|max:255',
+            'detail' => 'nullable|string|max:1000',
             'task_status_id' => 'required|integer',
             'assigner_id' => 'nullable|integer',
             'task_category_id' => 'nullable|integer',

--- a/html/laravel/app/Models/Task.php
+++ b/html/laravel/app/Models/Task.php
@@ -21,6 +21,7 @@ class Task extends Model
     protected $fillable = [
         'project_id',
         'name',
+        'detail',
         'task_kind_id',
         'task_status_id',
         'created_user_id',

--- a/html/laravel/app/Models/Task.php
+++ b/html/laravel/app/Models/Task.php
@@ -32,6 +32,7 @@ class Task extends Model
         'task_resolution_id',
     ];
 
+
     /**
      * ソート対象となる項目.
      *

--- a/html/laravel/database/migrations/2022_07_05_203830_add_detail_to_tasks_table.php
+++ b/html/laravel/database/migrations/2022_07_05_203830_add_detail_to_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDetailToTasksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->text('detail')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('detail');
+        });
+    }
+}

--- a/html/laravel/resources/lang/ja.json
+++ b/html/laravel/resources/lang/ja.json
@@ -179,6 +179,7 @@
     "Are you sure you want to delete this project? Once a project is deleted, all of its resources and data will be permanently deleted.": "本当にプロジェクトを削除してよろしいでしょうか？一度プロジェクトを削除すると、すべてのリソースとデータは永久に削除されます。",
     "Cancel": "閉じる",
     "Task Name": "課題名",
+    "Task Detail": "課題の詳細",
     "Task Kind": "種別",
     "Task Status": "状態",
     "Assigner": "担当者",

--- a/html/laravel/resources/lang/ja/validation.php
+++ b/html/laravel/resources/lang/ja/validation.php
@@ -117,7 +117,7 @@ return [
     'uploaded'             => ':attributeのアップロードに失敗しました。',
     'url'                  => ':attributeは、有効なURL形式で指定してください。',
     'uuid'                 => ':attributeは、有効なUUIDでなければなりません。',
-
+    
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Language Lines
@@ -151,6 +151,7 @@ return [
         'name' => '名前',
         'keyword' => 'キーワード',
         'kind' => '種別',
+        'detail' => '詳細',
         'status' => '状態',
         'assigner' => '担当者',
         'category' => 'カテゴリー',

--- a/html/laravel/resources/views/tasks/create.blade.php
+++ b/html/laravel/resources/views/tasks/create.blade.php
@@ -53,9 +53,16 @@
                     </div>
                 </div>
                 <div class="-mx-3 md:flex mb-6">
+                    <div class="md:w-full px-3 m-md-5">
+                        <x-label for="detail" :value="__('Task Detail')"  />
+                        <x-textarea id="detail" class="block mt-1 w-full h-64  {{ $errors->has('task_detail') ? 'border-red-600' :'' }}" type="text" name="detail" :value="old('detail')" placeholder="課題の詳細" autofocus />
+                    </div>
+                </div>
+                   
+                <div class="-mx-3 md:flex mb-6">
                     <div class="md:w-1/4 px-3 mb-6">
                         <x-label for="task_status_id" :value="__('Task Status')" class="{{ $errors->has('task_status_id') ? 'text-red-600' :'' }}" />
-                        <x-select :options="$task_statuses" id="task_status_id" class="block mt-1 w-full {{ $errors->has('task_status_id') ? 'border-red-600' :'' }}" type="text" name="task_status_id" :value="old('task_status_id')" required autofocus />
+                        <x-select :options="$task_statuses" id="task_status_id" class="block mt-1 w-fu11 {{ $errors->has('task_status_id') ? 'border-red-600' :'' }}" type="text" name="task_status_id" :value="old('task_status_id')" required autofocus />
                     </div>
 
                     <div class="md:w-1/4 px-3 mb-6">

--- a/html/laravel/resources/views/tasks/edit.blade.php
+++ b/html/laravel/resources/views/tasks/edit.blade.php
@@ -95,6 +95,12 @@
                         <x-input id="name" class="block mt-1 w-full {{ $errors->has('name') ? 'border-red-600' :'' }}" type="text" name="name" :value="old('name', $task->name)" placeholder="課題名" required autofocus />
                     </div>
                 </div>
+                <div class="-mx-3 md:flex mb-6">
+                    <div class="md:w-full px-3 m-md-5">
+                        <x-label for="detail" :value="__('Task Detail')" class="{{ $errors->has('detail') ? 'text-red-600' :'' }}" />
+                        <x-textarea id="detail" class="block mt-1 w-full h-64 {{ $errors->has('task_detail') ? 'border-red-600' :'' }}" type="text" name="detail" :value="old('detail', $task->detail)" placeholder="課題の詳細" autofocus />
+                    </div>
+                </div>
 
                 <div class="-mx-3 md:flex mb-6">
                     <div class="md:w-1/4 px-3 mb-6">


### PR DESCRIPTION
# 実装要件

・「課題作成ページ」および「課題編集ページ」に新しい項目「課題の詳細」を追加
・データベースへの項目追加(カラム名 detail)
・「課題の詳細」は、1,000文字まで保存できる。
　1,000文字を超える場合は、「課題の詳細は1000文字以下にしてください。」という旨のメッセージを表示する。
・改行はそのまま保存できる。
・入力は任意

# 実装内容

## tasksテーブルへdetailカラムを追加するマイグレーションファイルの追加
・detailカラムがnameカラムの右側へ追加される（データ型：text  NULLを許容）
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/63387780/181749507-47d744c9-dd09-4a54-bb1c-8d03f32ef1a0.png">
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/63387780/181750314-15a79e68-75ee-4ff8-ae09-13bfe59cb8a1.png">

## TaskController.phpへ課題の詳細に入力された文字数を1000文字以下に制限するvalidationを記述
・1000文字を超えるとvalidationErrorメッセージが表示される
<img width="1898" alt="image" src="https://user-images.githubusercontent.com/63387780/181749797-2afebc04-118e-4271-bc4c-4520c54f6835.png">

## resources/views/tasks/のcreate.blade.phpとedit.blade.phpへ課題の詳細の入力フォームの実装
・課題の作成と課題の編集画面へ「課題の詳細」入力フォームを実装
・任意入力を許容するのでrequired属性はありません
<img width="1869" alt="image" src="https://user-images.githubusercontent.com/63387780/181751475-c4f83e21-9d4f-4939-9daf-34f6b6315817.png">
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/63387780/181751568-8367affe-e4c8-498c-8378-fe2c04bccc65.png">
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/63387780/181751611-c56804ba-bd3f-423f-8e27-68f5f24165a5.png">

## resources/lang/へdetailの日本語化を記述
<img width="904" alt="image" src="https://user-images.githubusercontent.com/63387780/181752247-d3a4de3d-9be2-422e-a36c-4c1f57228f54.png">
<img width="1088" alt="image" src="https://user-images.githubusercontent.com/63387780/181752291-76080454-7f76-456b-bd97-06d2852a0eee.png">

## Models/Task.phpへdetailカラムの記述
<img width="968" alt="image" src="https://user-images.githubusercontent.com/63387780/181752784-b64c0fc6-4af0-479b-8d0f-f46bcd1932d5.png">
